### PR TITLE
Bump go and go-backstage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,5 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: |
-            ./coverage1.out
-            ./coverage2.out
+          files: ./coverage1.out,./coverage2.out
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,17 @@ jobs:
       - env:
           ACCTEST_SKIP_RESOURCE_TEST: "1"
           BACKSTAGE_BASE_URL: "https://demo.backstage.io"
-        run: go test -v -cover ./backstage
+        run: go test -v -cover -covermode=atomic -coverprofile=coverage1.out ./backstage
         timeout-minutes: 10
       - env:
           BACKSTAGE_BASE_URL: "http://localhost:${{ job.services.backstage.ports[7000] }}"
-        run: go test -v -cover ./backstage -run TestAccResourceLocation
+        run: go test -v -cover -covermode=atomic -coverprofile=coverage2.out ./backstage -run TestAccResourceLocation
         timeout-minutes: 10
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: |
+            ./coverage1.out
+            ./coverage2.out
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terraform Provider for Backstage
 
 [![Tests](https://github.com/tdabasinskas/terraform-provider-backstage/actions/workflows/test.yml/badge.svg)](https://github.com/tdabasinskas/terraform-provider-backstage/actions/workflows/test.yml)
-
+[![codecov](https://codecov.io/gh/tdabasinskas/terraform-provider-backstage/branch/main/graph/badge.svg?token=1QSZTX0N2B)](https://codecov.io/gh/tdabasinskas/terraform-provider-backstage)
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/tdabasinskas/terraform-provider-backstage?sort=semver)](https://github.com/tdabasinskas/terraform-provider-backstage/releases)
 [![registry](https://img.shields.io/static/v1?label=terraform&message=registry&color=blueviolet)](https://registry.terraform.io/providers/tdabasinskas/backstage/latest)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ most of the official documentation on developing this provider is also applicabl
 ### Requirements
 
 - [Terraform](https://www.terraform.io/downloads)
-- [Go](https://go.dev/doc/install) (1.19)
+- [Go](https://go.dev/doc/install) (1.20)
 - [GNU make](https://www.gnu.org/software/make/)
 - [Docker](https://docs.docker.com/get-docker/) (optional)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Terraform Provider for Backstage
 
 [![Tests](https://github.com/tdabasinskas/terraform-provider-backstage/actions/workflows/test.yml/badge.svg)](https://github.com/tdabasinskas/terraform-provider-backstage/actions/workflows/test.yml)
+
 [![go-github release (latest SemVer)](https://img.shields.io/github/v/release/tdabasinskas/terraform-provider-backstage?sort=semver)](https://github.com/tdabasinskas/terraform-provider-backstage/releases)
 [![registry](https://img.shields.io/static/v1?label=terraform&message=registry&color=blueviolet)](https://registry.terraform.io/providers/tdabasinskas/backstage/latest)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tdabasinskas/terraform-provider-backstage
 
-go 1.19
+go 1.20
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/stretchr/testify v1.8.1 // indirect
-	github.com/tdabasinskas/go-backstage v1.1.0 // indirect
+	github.com/tdabasinskas/go-backstage v1.1.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/tdabasinskas/go-backstage v1.0.2 h1:f6WOT5GIpU9mtoLJileUcb9EdKOIy4FFC
 github.com/tdabasinskas/go-backstage v1.0.2/go.mod h1:aw7tu1VydRX26637tLcUO32vjnYVayspe34kja49200=
 github.com/tdabasinskas/go-backstage v1.1.0 h1:OF0t5LdSgtMvMrqVkX09uOjRYj/WmqyMRK8r/6rFaU0=
 github.com/tdabasinskas/go-backstage v1.1.0/go.mod h1:aw7tu1VydRX26637tLcUO32vjnYVayspe34kja49200=
+github.com/tdabasinskas/go-backstage v1.1.1 h1:dBmObJWQ2qqzA/emGGttLGdPGhbehmXiQRC/HemEeXI=
+github.com/tdabasinskas/go-backstage v1.1.1/go.mod h1:vXZ8Ypc/feAftJXPJB5EATaf1ouu9w0YOXnbyzO+hyc=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Use the latest versions. Also, start uploading test coverage to CodeCov.