### PR TITLE
Fix flaky tests

### DIFF
--- a/backstage/data_source_entities_test.go
+++ b/backstage/data_source_entities_test.go
@@ -16,15 +16,15 @@ func TestAccDataSourceEntities(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.backstage_entities.test", "id", fmt.Sprint([]string{
 						"kind=user,metadata.name=janelle.dawe",
-						"metadata.uid=b70bed0a-e955-4f93-b03f-e03f7954da99",
+						"kind=component,metadata.description=Searcher",
 					})),
 					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.#", "2"),
-					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.kind", "User"),
-					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.metadata.annotations.backstage.io/managed-by-location",
+					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.kind", "Component"),
+					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.metadata.name", "searcher"),
+					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.relations.0.target_ref", "user:default/guest"),
+					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.1.kind", "User"),
+					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.1.metadata.annotations.backstage.io/managed-by-location",
 						"url:https://github.com/backstage/backstage/tree/master/packages/catalog-model/examples/acme/team-a-group.yaml"),
-					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.metadata.name", "janelle.dawe"),
-					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.1.metadata.uid", "b70bed0a-e955-4f93-b03f-e03f7954da99"),
-					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.0.relations.0.target_ref", "group:default/team-a"),
 					resource.TestCheckResourceAttr("data.backstage_entities.test", "entities.1.relations.0.target_ref", "group:default/team-a"),
 				),
 			},
@@ -36,7 +36,7 @@ const testAccDataSourceEntitiesConfig = `
 data "backstage_entities" "test" {
   filters = [
     "kind=user,metadata.name=janelle.dawe",
-    "metadata.uid=b70bed0a-e955-4f93-b03f-e03f7954da99",
+    "kind=component,metadata.description=Searcher",
   ]
 }
 `


### PR DESCRIPTION
Checking by UID makes the tests flaky, as it changes in the Backstage Demo instance.