### PR TITLE
Bump go-backstage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.20.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
-	github.com/tdabasinskas/go-backstage/v2 v2.0.0
+	github.com/tdabasinskas/go-backstage/v2 v2.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -189,10 +189,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/tdabasinskas/go-backstage/v2 v2.0.0 h1:LI+0d/DThfrd614Z2J3NO9vnqI+0bMMkvM75TKxboA8=
-github.com/tdabasinskas/go-backstage/v2 v2.0.0/go.mod h1:gtD+fcTPCOuXsLegAmQraXIo5lrNvG4g/S6xmW+tuUo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/tdabasinskas/go-backstage/v2 v2.1.0 h1:faVMlhfLggeHcGQkcGYe+Lo1BAUwNXUohvy5VrNSVXI=
+github.com/tdabasinskas/go-backstage/v2 v2.1.0/go.mod h1:JaxC2xda5bXfAsn0i/50n1/p9KygwFIADF5s340ufz8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
Bump to [v2.1.0](https://github.com/tdabasinskas/go-backstage/releases/tag/v2.1.0).