### PR TITLE
Populate headers from config differently

### DIFF
--- a/backstage/provider.go
+++ b/backstage/provider.go
@@ -132,9 +132,7 @@ func (p *backstageProvider) Configure(ctx context.Context, req provider.Configur
 		}
 	} else {
 		if !config.Headers.IsNull() {
-			for k, v := range config.Headers.Elements() {
-				headers[k] = v.String()
-			}
+			config.Headers.ElementsAs(ctx, &headers, true)
 		}
 	}
 

--- a/backstage/provider_test.go
+++ b/backstage/provider_test.go
@@ -7,6 +7,9 @@ import (
 
 const testAccProviderConfig = `
 provider "backstage" {
+  headers = {
+    "Custom-Header" = "header_value"
+  }
 }
 `
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,10 @@ provider "backstage" {
   base_url = "https://demo.backstage.io"
   # Override the name of default namespace:
   default_namespace = "custom-default"
+  # Set custom headers (might be useful for authentication):
+  headers = {
+    "Custom-Header" = "header_value"
+  }
 }
 ```
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -4,4 +4,8 @@ provider "backstage" {
   base_url = "https://demo.backstage.io"
   # Override the name of default namespace:
   default_namespace = "custom-default"
+  # Set custom headers (might be useful for authentication):
+  headers = {
+    "Custom-Header" = "header_value"
+  }
 }


### PR DESCRIPTION
Seems that `.String()` additional quotes on the string it returns. We should use `StringValue()`, but it's not available on the elements. `ElementsAs()` should resolve this.