### PR TITLE
feat(provider): add retry capability for API requests

### DIFF
--- a/.cspell/custom-dictionary.txt
+++ b/.cspell/custom-dictionary.txt
@@ -26,3 +26,5 @@ stringplanmodifier
 planmodifier
 jsondecode
 tfplugindocs
+retryablehttp
+retryable

--- a/backstage/provider.go
+++ b/backstage/provider.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-        "github.com/datolabs-io/go-backstage/v3"
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/backstage/provider.go
+++ b/backstage/provider.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-  "github.com/datolabs-io/go-backstage/v3"
+        "github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,3 +43,5 @@ provider "backstage" {
 - `base_url` (String) Base URL of the Backstage instance, e.g. https://demo.backstage.io. May also be provided via `BACKSTAGE_BASE_URL` environment variable.
 - `default_namespace` (String) Name of default namespace for entities (`default`, if not set). May also be provided via `BACKSTAGE_DEFAULT_NAMESPACE` environment variable.
 - `headers` (Map of String) Headers to be sent with each request to the Backstage API. Useful for authentication. May also be provided via `BACKSTAGE_HEADERS` environment variable.
+- `retries` (Number) Number of retries to attempt on recoverable API errors (default: 0). May also be provided via `BACKSTAGE_RETRIES` environment variable.
+- `timeout_seconds` (Number) Timeout for requests to the Backstage API in seconds (default: 15). May also be provided via `BACKSTAGE_TIMEOUT_SECONDS` environment variable.


### PR DESCRIPTION
Added support for retrying failed API requests through a new `retries` configuration option. This can help handle temporary network issues or service interruptions.

- Added new `retries` field to provider configuration
- Implemented retry logic using `go-retryablehttp`
- Support configuration via both provider config and `BACKSTAGE_RETRIES` environment variable
- Modified HTTP client setup to properly chain transports for both retries and headers
- Added request timeout configuration (`timeout_seconds`)

Partly addresses #160.