### PR TITLE
chore(deps): upgrade backstage sdk from v2 to v3

### DIFF
--- a/backstage/data_source_api.go
+++ b/backstage/data_source_api.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_component.go
+++ b/backstage/data_source_component.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_domain.go
+++ b/backstage/data_source_domain.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_entities.go
+++ b/backstage/data_source_entities.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_group.go
+++ b/backstage/data_source_group.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_location.go
+++ b/backstage/data_source_location.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_resource.go
+++ b/backstage/data_source_resource.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_system.go
+++ b/backstage/data_source_system.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/data_source_user.go
+++ b/backstage/data_source_user.go
@@ -6,13 +6,13 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/backstage/provider.go
+++ b/backstage/provider.go
@@ -3,6 +3,11 @@ package backstage
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -12,11 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 	"github.com/tdabasinskas/terraform-provider-backstage/internal/transport"
-	"net/http"
-	"os"
-	"regexp"
 )
 
 var _ provider.Provider = &backstageProvider{}

--- a/backstage/resource_location.go
+++ b/backstage/resource_location.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/datolabs-io/go-backstage/v3"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.35.0
 	github.com/stretchr/testify v1.9.0
-	github.com/tdabasinskas/go-backstage/v2 v2.5.1
+	github.com/datolabs-io/go-backstage/v3 v3.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/datolabs-io/go-backstage/v3 v3.0.0 h1:AaaA5PRhriPp+WM3siGEV5YLlV0IxXe2XIftsoi9wYg=
+github.com/datolabs-io/go-backstage/v3 v3.0.0/go.mod h1:xzfVJBuLKDbYXuYWmlimS9fX13OQYkYyl70UbQMeXXU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/transport/headers_transport_test.go
+++ b/internal/transport/headers_transport_test.go
@@ -2,11 +2,12 @@ package transport
 
 import (
 	"context"
-	"github.com/h2non/gock"
-	"github.com/stretchr/testify/assert"
-	"github.com/tdabasinskas/go-backstage/v2/backstage"
 	"net/http"
 	"testing"
+
+	"github.com/datolabs-io/go-backstage/v3"
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHeadersTransport_HeadersAdded(t *testing.T) {


### PR DESCRIPTION
Switched from `github.com/tdabasinskas/go-backstage/v2` to `github.com/datolabs-io/go-backstage/v3` across all files.

This change updates the SDK dependency to use the newer v3 version maintained by DatoLabs.